### PR TITLE
Condition upgrade to avoid calling remove() on empty array

### DIFF
--- a/src/leaflet-arrowheads.js
+++ b/src/leaflet-arrowheads.js
@@ -28,10 +28,8 @@ L.Polyline.include({
    buildVectorHats: function( options ){
 
       // Reset variables from previous this._update()
-      if (this._arrowheads){
+      if (this._arrowheads && this._arrowheads.length > 0){
          this._arrowheads.remove()
-         let arrowheads = []
-         let allhats = []
       }
 
       //  -------------------------------------------------------- //


### PR DESCRIPTION
Fix regarding https://github.com/slutske22/react-leaflet-arrowheads/issues/3 . Please update react repo also after you merge the changes.