### PR TITLE
Solved the "occsionally renders the arrowheads backwards" bug.

### DIFF
--- a/src/leaflet-arrowheads.js
+++ b/src/leaflet-arrowheads.js
@@ -184,7 +184,7 @@ L.Polyline.include({
 
                for (var i = 0; i < interpolatedPoints.length; i++) {
                   let bearing = L.GeometryUtil.angle( this._map, 
-                     interpolatedPoints[i].latLng, latlngs[ interpolatedPoints[i].predecessor ]
+                     latlngs[ interpolatedPoints[i].predecessor + 1 ], latlngs[ interpolatedPoints[i].predecessor ]
                   )
                   bearings.push(bearing)
                }


### PR DESCRIPTION
I guess the L.GeometryUtil.angle( ) doesn't like it when predecessor and hat latlng are too close together. Replaced with predecessor and next to predecessor, now working like a charm: https://imgur.com/a/ecbYGTQ

PS: love your library, it's so easy to use and straight to the point. Best regards.