### PR TITLE
Fixed crash on add to a LayerGroup that's not drawn. (Issue #15)

### DIFF
--- a/src/leaflet-arrowheads.js
+++ b/src/leaflet-arrowheads.js
@@ -338,15 +338,6 @@ L.Polyline.include({
       }
    },
 
-   addTo: function (map) {
-      map.addLayer(this);
-      if (this._hatsApplied) {
-         this.buildVectorHats(this._arrowheadOptions);
-         this._arrowheads.addTo(this._map);
-      }
-      return this;
-   },
-
    _update: function () {
       if (!this._map) {
          return;


### PR DESCRIPTION
The `addTo` method of the base class `L.Layer` does what is needed.

`_update` is called when the layer is added to the map. This ensures the correct behaviour, whether we are being added directly, or via a `LayerGroup` that might not be displayed.

As always, this could be dependent on the Leaflet version, it would need to be checked that this is the same behaviour all the way back.