### PR TITLE
Add endOffset for arrowheads, also dont show arrowheads if line is too small

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Arrowheads inherit all options from [L.Path](https://leafletjs.com/reference-1.6
       <td> endOffsetPixels </td>
       <td> Number <i color="grey"> ( pixels ) </i> </td>
       <td> 0 </td>
-      <td>  Defines the number of pixels from the end that the final arrowhead will be. </td>
+      <td>  Defines the number of pixels to offset the arrowhead from the vertex </td>
    </tr>
 
 </table>

--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ Arrowheads inherit all options from [L.Path](https://leafletjs.com/reference-1.6
       <td> false </td>
       <td> Only relevant when <code>size</code> is given as a percent. Useful when <code>frequency</code> is set to <code>'endonly'</code>.  Will render the arrowhead(s) with a size proportional to the entire length of the multi-segmented polyline, rather than proportional to the average length of all the segments.</td>
    </tr>
+ 
+    <tr>
+      <td> endOffsetPixels </td>
+      <td> Number <i color="grey"> ( pixels ) </i> </td>
+      <td> 0 </td>
+      <td>  Defines the number of pixels from the end that the final arrowhead will be. </td>
+   </tr>
 
 </table>
 

--- a/src/leaflet-arrowheads.js
+++ b/src/leaflet-arrowheads.js
@@ -22,7 +22,7 @@ L.Polyline.include({
 		return this;
 	},
 	
-	disToPixeldistance: function (distance) {
+  disToPixeldistance: function (distance) {
     var l2 = L.GeometryUtil.destination(this._map.getCenter(),90,distance);
     var p1 = this._map.latLngToContainerPoint(this._map.getCenter())
     var p2 = this._map.latLngToContainerPoint(l2)

--- a/src/leaflet-arrowheads.js
+++ b/src/leaflet-arrowheads.js
@@ -248,24 +248,24 @@ L.Polyline.include({
 				let thetaLeft = (180 - bearing - options.yawn / 2) * (Math.PI / 180),
 					thetaRight = (180 - bearing + options.yawn / 2) * (Math.PI / 180);
 					
-			  if (options.endOffsetPixels) {
-			    if (peiceLengthInPixels < sizePixels + options.endOffsetPixels) {
-			      return;
-			    }
-			    const pointA = {
-			      x: derivedXY.x + (options.endOffsetPixels * Math.sin(thetaLeft)),
-			      y: derivedXY.y + (options.endOffsetPixels * Math.cos(thetaLeft))
-			    };
-			    const pointB = {
-			     x: derivedXY.x + (options.endOffsetPixels * Math.sin(thetaRight)),
-           y: derivedXY.y + (options.endOffsetPixels * Math.cos(thetaRight))
-			    }
-          derivedXY = {
-            x: (pointA.x + pointB.x) / 2,
-            y: (pointA.y + pointB.y) / 2
-          }
-          head = this._map.layerPointToLatLng(derivedXY);
-        }
+				if (options.endOffsetPixels) {
+					if (peiceLengthInPixels < sizePixels + options.endOffsetPixels) {
+						return;
+					}
+					const pointA = {
+						x: derivedXY.x + (options.endOffsetPixels * Math.sin(thetaLeft)),
+						y: derivedXY.y + (options.endOffsetPixels * Math.cos(thetaLeft))
+					};
+					const pointB = {
+						x: derivedXY.x + (options.endOffsetPixels * Math.sin(thetaRight)),
+						y: derivedXY.y + (options.endOffsetPixels * Math.cos(thetaRight))
+					}
+					derivedXY = {
+						x: (pointA.x + pointB.x) / 2,
+						y: (pointA.y + pointB.y) / 2
+					}
+					head = this._map.layerPointToLatLng(derivedXY);
+				}
 
 				let dxLeft = sizePixels * Math.sin(thetaLeft),
 					dyLeft = sizePixels * Math.cos(thetaLeft),

--- a/src/leaflet-arrowheads.js
+++ b/src/leaflet-arrowheads.js
@@ -262,6 +262,15 @@ L.Polyline.include({
 						x: derivedXY.x - legLength * Math.sin(thetaRight),
 						y: derivedXY.y - legLength * Math.cos(thetaRight),
 					};
+					/*        
+						     Old Vertex
+							A
+					               / \
+					              /   \
+					   Point A - /_____\ - Point B
+					                |
+					            New Vertex
+					*/
 					derivedXY = {
 						x: (pointA.x + pointB.x) / 2,
 						y: (pointA.y + pointB.y) / 2

--- a/src/leaflet-arrowheads.js
+++ b/src/leaflet-arrowheads.js
@@ -252,14 +252,16 @@ L.Polyline.include({
 					if (peiceLengthInPixels < sizePixels + options.endOffsetPixels) {
 						return;
 					}
+					// legs of isosceles triangle used to make sure distance from vertex is correct
+					const legLength = options.endOffsetPixels / Math.cos(options.yawn);
 					const pointA = {
-						x: derivedXY.x + (options.endOffsetPixels * Math.sin(thetaLeft)),
-						y: derivedXY.y + (options.endOffsetPixels * Math.cos(thetaLeft))
+						x: derivedXY.x - legLength * Math.sin(thetaLeft),
+						y: derivedXY.y - legLength * Math.cos(thetaLeft),
 					};
 					const pointB = {
-						x: derivedXY.x + (options.endOffsetPixels * Math.sin(thetaRight)),
-						y: derivedXY.y + (options.endOffsetPixels * Math.cos(thetaRight))
-					}
+						x: derivedXY.x - legLength * Math.sin(thetaRight),
+						y: derivedXY.y - legLength * Math.cos(thetaRight),
+					};
 					derivedXY = {
 						x: (pointA.x + pointB.x) / 2,
 						y: (pointA.y + pointB.y) / 2

--- a/src/leaflet-arrowheads.js
+++ b/src/leaflet-arrowheads.js
@@ -265,11 +265,11 @@ L.Polyline.include({
 					/*        
 						     Old Vertex
 							A
-					               / \
-					              /   \
-					   Point A - /_____\ - Point B
+					               /|\
+					              / | \
+					   Point A - /__|__\ - Point B
 					                |
-					            New Vertex
+					            New Vertex "offset" distance from old vertex
 					*/
 					derivedXY = {
 						x: (pointA.x + pointB.x) / 2,

--- a/src/leaflet-arrowheads.js
+++ b/src/leaflet-arrowheads.js
@@ -22,12 +22,12 @@ L.Polyline.include({
 		return this;
 	},
 	
-  disToPixeldistance: function (distance) {
-    var l2 = L.GeometryUtil.destination(this._map.getCenter(),90,distance);
-    var p1 = this._map.latLngToContainerPoint(this._map.getCenter())
-    var p2 = this._map.latLngToContainerPoint(l2)
-    return p1.distanceTo(p2)
-  },
+	disToPixeldistance: function (distance) {
+		var l2 = L.GeometryUtil.destination(this._map.getCenter(),90,distance);
+		var p1 = this._map.latLngToContainerPoint(this._map.getCenter())
+		var p2 = this._map.latLngToContainerPoint(l2)
+		return p1.distanceTo(p2)
+	},
 
 	buildVectorHats: function (options) {
 		// Reset variables from previous this._update()
@@ -362,10 +362,6 @@ L.Polyline.include({
 			delete this._arrowheadOptions;
 			this._hatsApplied = false;
 		}
-	},
-	
-	redraw: function() {
-	  this._update();
 	},
 
 	_update: function () {


### PR DESCRIPTION
This library is working great but I am really needing an offset when using pixel size arrowheads. This PR adds a endOffsetPixels option and also will hide arrows when they are are bigger than the piece of line they are attached to.

Geometry is not a strong suit of mine so I am open to feedback here. There may be an easier way to do what I am doing.